### PR TITLE
Implemented URL validation against new files contained in PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog-link-check",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "GitHub action to detect and block pull requests with invalid links in changelog files",
   "main": "lib/index.js",
   "scripts": {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -15,9 +15,11 @@ export async function checkFilesForBrokenLinks(
     'gim'
   );
 
+  const newUrls = getListOfNewUrls(files);
+
   for (const file of files) {
     if (shouldCheckFile(file.filename, fileUrlRegex)) {
-      const errorLines = await checkFileForBrokenLinks(file.raw_url);
+      const errorLines = await checkFileForBrokenLinks(file.raw_url, newUrls);
       if (errorLines.length > 0) {
         errorFiles.push({
           fileName: file.filename,
@@ -36,7 +38,8 @@ export function shouldCheckFile(file: string, match: RegExp): boolean {
 }
 
 export async function checkFileForBrokenLinks(
-  fileUrl: string
+  fileUrl: string,
+  newUrls: string[]
 ): Promise<number[]> {
   const response = await fetch(fileUrl);
   const content = await response.text();
@@ -44,7 +47,7 @@ export async function checkFileForBrokenLinks(
 
   const errorLines: number[] = [];
   for (let i = 0; i < lines.length; i += 1) {
-    if (await isLineInvalid(lines[i])) {
+    if (await isLineInvalid(lines[i], newUrls)) {
       errorLines.push(i + 1);
     }
   }
@@ -52,13 +55,16 @@ export async function checkFileForBrokenLinks(
   return errorLines;
 }
 
-export async function isLineInvalid(line: string): Promise<boolean> {
+export async function isLineInvalid(
+  line: string,
+  newUrls: string[]
+): Promise<boolean> {
   const mdLink = /\[.*\]\((?<url>.*)\)/g;
 
   const matches = line.matchAll(mdLink);
   for (const match of matches) {
     const url = match.groups?.url;
-    if (await isUrlInvalid(url)) {
+    if (await isUrlInvalid(newUrls, url)) {
       return true;
     }
   }
@@ -66,7 +72,10 @@ export async function isLineInvalid(line: string): Promise<boolean> {
   return false;
 }
 
-export async function isUrlInvalid(url?: string): Promise<boolean> {
+export async function isUrlInvalid(
+  newUrls: string[],
+  url?: string
+): Promise<boolean> {
   if (!url) return true;
 
   // Is it formatted correctly?
@@ -79,10 +88,13 @@ export async function isUrlInvalid(url?: string): Promise<boolean> {
   // Does it resolve?
   try {
     const response = await fetch(url, { method: 'HEAD' });
-    return !response.ok;
+    if (response.ok) return false;
   } catch (e) {
     return true;
   }
+
+  // Is it a new file in this PR that isn't published yet?
+  return !newUrls.includes(url);
 }
 
 export function generatePrComment(errorFiles: FileBrokenLinks[]): string {
@@ -97,4 +109,57 @@ export function generatePrComment(errorFiles: FileBrokenLinks[]): string {
   return `${UserStrings.PR_REPORT_HEADER}
 ${fileList}
 ${UserStrings.PR_REPORT_FOOTER}`;
+}
+
+export function getListOfNewUrls(files: PullListFile[]): string[] {
+  const newUrls: string[] = [];
+
+  for (const file of files) {
+    if (file.status === 'added') {
+      const url = generateGraphUrl(file.filename);
+      if (url) {
+        newUrls.push(url);
+      }
+    }
+  }
+
+  return newUrls;
+}
+
+const graphRootUrl = 'https://learn.microsoft.com/en-us/graph';
+
+export function generateGraphUrl(fileName: string): string | undefined {
+  const fileNameNoExtension = fileName.replace(/\.[^.]*$/, '');
+
+  if (fileNameNoExtension.startsWith('api-reference')) {
+    // Reference topic
+    const pathParts = fileNameNoExtension.split('/');
+
+    if (pathParts[2] !== 'api' && pathParts[2] !== 'resources') {
+      // Not valid
+      return undefined;
+    }
+
+    let relativeUrl = `/${pathParts[2] === 'api' ? 'api' : 'api/resources'}`;
+
+    if (pathParts[1] !== 'v1.0' && pathParts[1] !== 'beta') {
+      // Not valid
+      return undefined;
+    }
+    let version = pathParts[1];
+    if (version.startsWith('v')) {
+      version = '1.0';
+    }
+
+    const restOfUrl = pathParts.slice(3).join('/');
+
+    relativeUrl = `${relativeUrl}/${restOfUrl}?view=graph-rest-${version}`;
+
+    return `${graphRootUrl}${relativeUrl}`;
+  } else if (fileNameNoExtension.startsWith('concepts')) {
+    const relativeUrl = fileNameNoExtension.replace(/^concepts/, '');
+    return `${graphRootUrl}${relativeUrl}`;
+  } else {
+    return undefined;
+  }
 }

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@jest/globals';
 import nock from 'nock';
-import { FileBrokenLinks } from '../src/types';
+import { FileBrokenLinks, PullListFile } from '../src/types';
 import {
   checkFileForBrokenLinks,
+  checkFilesForBrokenLinks,
   generatePrComment,
   isLineInvalid,
   isUrlInvalid,
@@ -194,4 +195,218 @@ Please add a commit to this branch that fixes the invalid links.`;
 
 test('PR comment generates correctly', () => {
   expect(generatePrComment(errorFiles)).toBe(expectedPrComment);
+});
+
+const pullListFiles: PullListFile[] = [
+  {
+    sha: '',
+    filename: 'changelog/changelog.json',
+    status: 'added',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: 'https://github.com/changelog.json',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/beta/api/user-list.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/v1.0/api/user-list.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/beta/resources/user.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/v1.0/resources/user.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/beta/api/new-api.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/v1.0/api/new-api.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/beta/resources/new-resource.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'api-reference/v1.0/resources/new-resource.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+  {
+    sha: '',
+    filename: 'concepts/new-conceptual-topic.md',
+    status: 'modified',
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+    blob_url: '',
+    raw_url: '',
+    contents_url: ''
+  },
+];
+
+const changeLogFileWithNewFiles = `{
+  "changelog": [
+    {
+      "ChangeList": [
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/api/user-list?view=graph-rest-beta).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/resources/user?view=graph-rest-beta).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/resources/user?view=graph-rest-1.0).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/api/new-api?view=graph-rest-beta).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/api/new-api?view=graph-rest-1.0).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/resources/new-resource?view=graph-rest-beta).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/resources/new-resource?view=graph-rest-1.0).",
+          "Target": "Financials API reference"
+        },
+        {
+          "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Financials API reference",
+          "ChangeType": "Addition",
+          "Description": "Changed [link](https://learn.microsoft.com/en-us/graph/new-conceptual-topic).",
+          "Target": "Financials API reference"
+        }
+      ],
+      "Id": "230ea331-2105-45d0-bb78-bc0063bc729f",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2019-03-01T00:00:00",
+      "WorkloadArea": "Financials",
+      "SubArea": ""
+    }
+  ]
+}`;
+
+test('URLs to files added in PR should not fail validation', async () => {
+  nock('https://github.com')
+    .replyContentLength()
+    .get('/changelog.json')
+    .reply(200, changeLogFileWithNewFiles, {
+      'Content-Type': 'application/json; charset=utf-8',
+    });
+
+  const changeLogDirectory = 'changelog';
+  const errorFiles = await checkFilesForBrokenLinks(pullListFiles, changeLogDirectory);
+
+  expect(errorFiles.length).toBe(0);
 });


### PR DESCRIPTION
Previously, URLs were validated by simply seeing if they were live or not. This did not account for URLs that *will go live* when the PR is merged.

This new check will generate the corresponding URL for files that are shown as 'added' and will consider those valid.

Fixes #15 