### PR TITLE
Keep list of good and bad URLs to reduce network requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog-link-check",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "GitHub action to detect and block pull requests with invalid links in changelog files",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
No sense in re-checking a URL once we've already checked it.